### PR TITLE
Nuxt 2 5 0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,8 @@ const NuxtPlugin = {
 
         // Create nuxt instance using options
         const nuxt = new Nuxt(config)
+        await nuxt.ready();
+
         server.expose('nuxt', nuxt)
 
         // Nuxt handler
@@ -38,7 +40,7 @@ const NuxtPlugin = {
             },
             handler (request, h) {
                 const {req, res} = request.raw
-                
+
                 nuxt.render(req, res)
 
                 // https://hapijs.com/api#h.abandon

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ const NuxtPlugin = {
 
         // Create nuxt instance using options
         const nuxt = new Nuxt(config)
-        await nuxt.ready();
+        await nuxt.ready()
 
         server.expose('nuxt', nuxt)
 
@@ -40,7 +40,6 @@ const NuxtPlugin = {
             },
             handler (request, h) {
                 const {req, res} = request.raw
-
                 nuxt.render(req, res)
 
                 // https://hapijs.com/api#h.abandon


### PR DESCRIPTION
From: https://github.com/nuxt/nuxt.js/releases/tag/v2.5.0

> If not already done, please explicitly call nuxt.ready() after new Nuxt(). nuxt.ready() was always async, but not awaiting the function call has now a severe impact.