### PR TITLE
  feat: pass through hapi's request and response internals to nuxt

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ await server.register(HapiNuxt)
 const { nuxt, builder } = server.plugins.nuxt
 ```
 
+## Access Hapi's internals.
+
+The hapi request object is available from `nuxtServerInit` and the `context` under `res.hapi`. Likewise, the hapi response toolkit will be available in `res.hapi`.
+
 ## Development
 
 1. Clone this repository

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -51,6 +51,8 @@ exports.register = async function (server, _config) {
     },
     handler (request, h) {
       const { req, res } = request.raw
+      req.hapi = request;
+      res.hapi = h;
       nuxt.render(req, res)
 
       // https://hapijs.com/api#h.abandon


### PR DESCRIPTION
I ran into this issue on a recent project using this plugin. I would like to access hapi's internals to be able to use Hapi's plugins with nuxt. A prime example is csrf. Hapi has a plugin for this that is passed through their request object. Because the nuxt renderer doesn't take in the Hapi request object, this token is not available to nuxtServerInit or other places with the server context.

This change adds the Hapi response toolkit and request object to the `res` and `req` objects respectively. This allows clients to access them in their code.