### PR TITLE
Loading nuxt.config.js file bug fix

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -32,7 +32,7 @@ exports.register = async function (server, _config) {
   nuxtConfig.dev = config.dev
 
   // Create nuxt instance using options
-  const nuxt = new Nuxt(nuxtConfig)
+  const nuxt = new Nuxt(nuxtConfig.default)
 
   // Await nuxt to be ready
   await nuxt.ready()


### PR DESCRIPTION
This fixes #54 as newer nuxt.config.js uses `export default`.